### PR TITLE
Fix install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A command-line tool to check for CIDR overlap before creating a new subnet in Go
 ## Installation
 
 ```
-go install github.com/guni1192/google-cloud-subnet-checker@latest
+go install github.com/guni1192/google-cloud-subnet-checker/cmd/google-cloud-subnet-checker@latest
 ```
 
 ### Options


### PR DESCRIPTION
## Summary
- Update go install command to include the correct cmd path that contains the package binary
- This fixes the issue where `go install github.com/guni1192/google-cloud-subnet-checker@latest` fails because the package is located at `cmd/google-cloud-subnet-checker`

## Test plan
- [x] Verified the correct install path by testing the command
- [x] Updated README with the working install command

The current command in README fails with:
```
go: github.com/guni1192/google-cloud-subnet-checker@latest: module github.com/guni1192/google-cloud-subnet-checker@latest found (v0.0.0-20250130191521-c5711c32a60e), but does not contain package github.com/guni1192/google-cloud-subnet-checker
```

The correct command should include the cmd path:
```
go install github.com/guni1192/google-cloud-subnet-checker/cmd/google-cloud-subnet-checker@latest
```

🤖 Generated with [Claude Code](https://claude.ai/code)